### PR TITLE
Added 1.8 blocks

### DIFF
--- a/blockdefs/minecraft.yaml
+++ b/blockdefs/minecraft.yaml
@@ -463,6 +463,9 @@ blocks:
       1: [0, 12]  # Sandstone
       2: [4, 0]   # Plank
       3: [0, 1]   # Cobblestone
+      4: [7, 0]   # Brick
+      5: [6, 3]   # Stone brick
+      0: [6, 0]   # Smooth stone #2 (???)
     type: HALFHEIGHT
   
   - id: 45
@@ -841,4 +844,104 @@ blocks:
     mapcolor: [143, 107, 53]
     tex: [4, 5]
     type: TRAPDOOR
+  
+  - id: 97
+    idStr: STONE_SILVERFISH
+    name: Stone containing Silverfish
+    mapcolor: [120, 120, 120] #TODO: should this visually indicate that a silverfish is inside?
+    tex: [1, 0]
+  
+  - id: 98
+    idStr: STONE_BRICK
+    name: Stone Brick
+    mapcolor: [120, 120, 120]
+    tex: [6, 3]
+    tex_data:
+      0: [6, 3]   # Stone Brick
+      1: [4, 6]  # Mossy
+      2: [5, 6]   # Cracked
+  
+  #huge mushruooms are complicated as fuck, thus i didn’t do them for now:
+  #http://www.minecraftwiki.net/wiki/Data_values#Huge_brown_and_red_mushroom
+  
+  - id: 99
+    idStr: HUGE_BROWN_MUSHROOM
+    name: Huge Brown Mushroom
+    mapcolor: [145, 110, 85]
+    tex: [14, 7]
+    tex_direction:
+      BOTTOM: [14, 8]
+  
+  - id: 100
+    idStr: HUGE_RED_MUSHROOM
+    name: Huge Red Mushroom
+    mapcolor: [117, 25, 23]
+    tex: [13, 7]
+    tex_direction:
+      BOTTOM: [14, 8]
+  
+  - id: 101
+    idStr: IRON_BARS
+    name: Iron Bars
+    mapcolor: [115, 115, 115]
+    tex: [5, 5]
+    type: FENCE #TODO: better type for iron bars and glass panes
+  
+  - id: 102
+    idStr: GLASS_PANE
+    name: Glass Pane
+    mapcolor: [255, 255, 255]
+    tex: [1, 3]
+    type: FENCE #TODO: better type for iron bars and glass panes
+  
+  - id: 103
+    idStr: MELON
+    name: Melon
+    mapcolor: [146, 192, 0] #stolen from crops
+    tex: [8, 8]
+    tex_direction:
+      TOP:    [9, 8]
+      BOTTOM: [9, 8]
+  
+  - id: 104
+    idStr: PUMPKIN_STEM
+    name: Pumpkin Stem
+    mapcolor: [100, 67, 50] #stolen from sugarcane
+    tex: [15, 6]
+    type: DECORATION_CROSS
+  
+  - id: 105
+    idStr: MELON_STEM
+    name: Melon Stem
+    mapcolor: [100, 67, 50] #stolen from sugarcane
+    tex: [15, 6]
+    type: DECORATION_CROSS
+  
+  - id: 106
+    idStr: VINES
+    name: Vines
+    mapcolor: [117, 176, 73] #stolen from grass
+    tex: [15, 8]
+    type: SEMISOLID #wrong, but best-fitting (i guess). uses a similar system as fire, i.e. textured sheets on each side where blocks are adjacent.
+  
+  - id: 107
+    idStr: FENCE_GATE
+    name: Fence Gate
+    mapcolor: [157, 128, 79]
+    tex: [4, 0]
+    type: PORTAL #more like fence, but it would look identical to it so better this
+  
+  - id: 108
+    idStr: BRICK_STAIRS
+    name: Brick Stairs
+    mapcolor: [170, 86, 62]
+    tex: [7, 0]
+    type: STAIRS
+  
+  - id: 109
+    idStr: STONE_BRICK_STAIRS
+    name: Stone Brick Stairs
+    mapcolor: [120, 120, 120]
+    tex: [6, 3]
+    type: STAIRS
 ...


### PR DESCRIPTION
…well, i was too lazy for the shrooms, and xray has no block types fitting for panels (glass pane & iron bars) and the fence gate. fire is hardcoded, else it would fit quite good to the vines.

at least it’s better than nothing :D

note that i didn’t test the alternative data values for the stone brick, as toomanyitems (the the mod i placed the blocks in my test world with) doesn’t offer them. oh, and the new creative mode neither (it doesn’t even have melons!)
